### PR TITLE
Fixes non-form buttons and Create Profile functionality

### DIFF
--- a/app/functions-orsd.js
+++ b/app/functions-orsd.js
@@ -381,11 +381,13 @@ function runScript(filename){
 function oProfile(){
 	load(true)
 	user = document.getElementById("profile_name").value;
+	days = document.getElementById("expiration_days").value;
 	$.ajax({
 		method:'post',
 		url:'./app/profile.php',
 		data:{
-			profile:user
+			profile:user,
+			days:days
 		},
 		success:function(result) {
 			load(false);
@@ -423,7 +425,8 @@ function rProfile(user){
 }
 function createProfile(){
 	profileForm = '<input class="form-control" type="text" placeholder="Profile Name" name="profile_name" id="profile_name">';
-	profileForm += '<br /><br /> <button class="btn btn-sm btn-raised btn-info pull-right" onclick="oProfile();">Create Profile</button><br /><br />';
+	profileForm += '<br /><input class="form-control" type="text" placeholder="Expiration Days" name="expiration_days" id="expiration_days">';
+	profileForm += '<br /><br /> <button class="btn btn-sm btn-raised btn-info pull-right" type="button" onclick="oProfile();">Create Profile</button><br /><br />';
 
 	genModal("Create new PiVPN Profile", profileForm);
 

--- a/app/profile.php
+++ b/app/profile.php
@@ -6,10 +6,15 @@ if(!isset($_SESSION['username'])){
 	die("You must be logged in to view this page!");
 }
 if(!isset($_POST['profile'])){ die("No profile name selected!"); }
+$days = 1080; // Days is set with a default prompt value.
+if (isset($_POST['days']))
+{
+    $days = $_POST['days'];
+}
 $pro = $_POST['profile'];
-add_vpn_profile($pro);
+add_vpn_profile($pro, $days);
 //Run selected script, but only if it exists in the scr_up folder.
-function add_vpn_profile($profile) {
+function add_vpn_profile($profile, $d) {
 	
     // Open a handle to expect in write mode
     $p = popen('sudo /usr/bin/expect','w');
@@ -24,6 +29,8 @@ function add_vpn_profile($profile) {
     $cmd .= "send \"pivpn add nopass\\r\"; ";
     $cmd .= "expect \"Enter a Name for the Client:   \"; ";
     $cmd .= "send \"$profile\\r\"; ";
+    $cmd .= "expect \"How many days should the certificate last?  $d\"; ";
+    $cmd .= "send \"\\b\\b\\b\\b$d\\r\"; ";
     $cmd .= "expect \"for easy transfer.\"; ";
     // Commit the command to expect & close
     fwrite($p, $cmd); pclose ($p);

--- a/pages/openvpn.php
+++ b/pages/openvpn.php
@@ -12,7 +12,7 @@ echo '';
             <h1 class="page-header">PiVPN Profiles <small><a href="#"><div onClick="pageLoad('PiVPN');" class="fa fa-refresh rotate"></div></a></small></h1>
 	    <small>This page only works with <a href="http://pivpn.io" target="_blank">pivpn.io</a></small>
 		<br />
-		<button class="btn btn-sm btn-raised btn-info" onclick="createProfile()">Create VPN Profile</button>
+		<button class="btn btn-sm btn-raised btn-info" type="button" onclick="createProfile()">Create VPN Profile</button>
         </div>
     </div>
     <div class="row">


### PR DESCRIPTION
- app\functions-orsd.js
~ Added days var to oProfile()
~ Added input expiration days to createProfile() form
~ Added type="button" to Create Profile button in createProfile() form
- app\profile.php
~ Added days var defaulted to 1080
~ Checking for 'days' on $_POST and overwritting default value of $days
~ Added $d param to add_vpn_profile function
~ Added another expect command to the $cmd string 📓 I have tested this expect and it works properly for pivpn v 1.9
~ Added send (deletes the default entered value) uses $d for value 📓 I have not tested this send
- pages\openvpn.php
~ type="button" fix